### PR TITLE
Allow implicitly cloning arguments instead of referencing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub fn autoprops_component(
     let mut fields = Vec::new();
     let mut arg_types = Vec::new();
     let mut clones = Vec::new();
+    let mut partial_eq_constraints = Vec::new();
     for input in function.sig.inputs.iter() {
         if let FnArg::Typed(PatType { pat, ty, attrs, .. }) = input {
             let mut end_ty = ty;
@@ -104,12 +105,11 @@ pub fn autoprops_component(
                 pub #pat: #end_ty
             });
             arg_types.push(ty.clone());
+            partial_eq_constraints.push(quote! { #end_ty: PartialEq, });
         } else {
             panic!("Invalid argument");
         }
     }
-
-    let partial_eq_constraints = arg_types.iter().map(|ty| quote! { #ty: PartialEq });
 
     let struct_name = syn::Ident::new(&format!("{}Props", fn_name), Span::call_site().into());
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
@@ -120,8 +120,8 @@ pub fn autoprops_component(
     } else {
         quote! {
             where
-                #(#partial_eq_constraints),*
-                #bounds,
+                #(#partial_eq_constraints)*
+                #bounds
         }
     };
 

--- a/tests/cases/allow-refs-pass.rs
+++ b/tests/cases/allow-refs-pass.rs
@@ -1,3 +1,4 @@
+use yew::prelude::*;
 use yew_autoprops::autoprops_component;
 
 #[autoprops_component]

--- a/tests/cases/require-refs-fail.stderr
+++ b/tests/cases/require-refs-fail.stderr
@@ -1,7 +1,0 @@
-error: custom attribute panicked
- --> tests/cases/require-refs-fail.rs:3:1
-  |
-3 | #[autoprops_component]
-  | ^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: message: Invalid argument: test : i8 (must be a reference)


### PR DESCRIPTION
I just discovered this great library yesterday and I think it's fantastic!

Here is a new improvement for it that will allow the user to be more productive
by not having to deal with references all the time.

This PR allow the user to write types that are not references. If they are not,
the value will be cloned at the beginning of the function.

Properties in Yew should ideally be cheap-to-clone because they are passed from
parent to children by cloning. So it is safe to assume that the user will want
the actual types most of the time instead of references.

Here is an example of its usage:

```
use yew_autoprops::autoprops_component;
use yew::prelude::*;

#[autoprops_component]
fn CoolComponent( bool1: &bool, bool2: bool, int1: &i8, int2: i8) -> Html {
    if *bool1 {
    }

    if bool2 {
    }

    if int1 > &5 {
    }

    if int2 > 5 {
    }

    html! {
        <div>
        </div>
    }
}
```
