### PR TITLE
Allow customizing the struct properties name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,37 @@ pub fn autoprops_component(
     let visibility = &function.vis;
     let generics = &function.sig.generics;
 
-    let component_name = match args.len() {
-        0 => None,
+    let (component_name, struct_name) = match args.len() {
+        0 => (
+            None,
+            Some(syn::Ident::new(
+                &format!("{}Props", fn_name),
+                Span::call_site().into(),
+            )),
+        ),
         1 => {
             let TokenTree::Ident(name) = &args[0] else {
                 panic!("Invalid argument: {}", args[0].to_string());
             };
 
-            Some(name)
+            (
+                Some(name),
+                Some(syn::Ident::new(
+                    &format!("{}Props", name),
+                    Span::call_site().into(),
+                )),
+            )
+        }
+        3 => {
+            let TokenTree::Ident(name) = &args[0] else {
+                panic!("Invalid argument: {}", args[0].to_string());
+            };
+
+            let TokenTree::Ident(props) = args[2].clone() else {
+                panic!("Invalid argument: {}", args[2].to_string());
+            };
+
+            (Some(name), Some(props))
         }
         _ => panic!("Invalid arguments: {:?}", args),
     };
@@ -108,7 +131,6 @@ pub fn autoprops_component(
 
     let partial_eq_constraints = arg_types.iter().map(|ty| quote! { #ty: PartialEq });
 
-    let struct_name = syn::Ident::new(&format!("{}Props", fn_name), Span::call_site().into());
     let (impl_generics, ty_generics, _) = generics.split_for_impl();
     let bounds = generics.where_clause.clone();
 

--- a/tests/cases/partialeq-fail.stderr
+++ b/tests/cases/partialeq-fail.stderr
@@ -12,5 +12,6 @@ note: an implementation of `PartialEq` might be missing for `NotPartialEq`
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotPartialEq` with `#[derive(PartialEq)]`
    |
-14 | #[derive(PartialEq)]
+14 + #[derive(PartialEq)]
+15 | struct NotPartialEq();
    |


### PR DESCRIPTION
This change will allow the user to customize the name of the Properties struct.
Most of the time the user won't care so the default will be as before but in
case they do care (when making libraries of components for example), this is
now possible.

```
use yew_autoprops::autoprops_component;
use yew::prelude::*;

#[autoprops_component(CoolComponent, CoolProps)]
fn cool_component(#[prop_or_default] test: &i8, smth: &usize) -> Html {
    println!("test: {}", test);

    html! {
        <div>
            <p>{ smth }</p>
        </div>
    }
}

impl CoolProps {
    fn foo() {
    }
}
```
